### PR TITLE
Fix dividers

### DIFF
--- a/1-introduction.html
+++ b/1-introduction.html
@@ -87,7 +87,7 @@ class: center, middle
 
 .image-80[![Big snake](images/Black-Snake-White-Background-Images.jpg)]
 
---- 
+---
 # Monkeys can do that, too
 
 Vervet monkeys
@@ -98,7 +98,7 @@ Vervet monkeys
    - Leopard call (video stim): <br> https://www.youtube.com/watch?v=hEzT-85gEdA 0:00-0:18
    - Eagle call (actual eagle): <br> https://www.youtube.com/watch?v=KRVxqCo9iW8 0:52-1:05
 
---- 
+---
 # Bees are pretty sophisticated
 
 - Bees: The waggle dance 
@@ -211,7 +211,7 @@ frameborder="0" allowFullScreen></iframe>
 
 .footnote[.red[*] 0:00-0:30, https://www.youtube.com/watch?v=xwjBZ0tHwZQ ]
 
-??? 
+???
 
 6 year old girl playing "Puppy waltz", Chopin, Op. 64 No. 1
 


### PR DESCRIPTION
Fixes #1 and #2. This is terrible, but the problem was just that trailing spaces at the end of the `---` and `???` lines were making them not be interpreted as dividers. You can run something like this:

``` bash
grep -r ".*\s$" 1-introduction.html 
```

To make sure there are no trailing spaces in places there shouldn't be.
